### PR TITLE
Pimp 115 refactor group controller

### DIFF
--- a/src/main/java/com/pimp/controller/GroupController.java
+++ b/src/main/java/com/pimp/controller/GroupController.java
@@ -30,9 +30,15 @@ public abstract class GroupController<T extends Group> {
         return groupService.findByUserName(userName);
     }
 
+    @Deprecated
     @RequestMapping(method = GET, path = "/{name}")
     public T get(@PathVariable String name) {
         return groupService.find(name);
+    }
+
+    @RequestMapping(method = GET, path = "/id/{key}")
+    public T getByKey(@PathVariable String key) {
+        return groupService.findByKey(key);
     }
 
     @RequestMapping(method = POST)

--- a/src/main/java/com/pimp/repositories/GroupRepository.java
+++ b/src/main/java/com/pimp/repositories/GroupRepository.java
@@ -12,4 +12,6 @@ public interface GroupRepository<T extends Group> extends MongoRepository<T, Str
 
     @Query("{userNames:{$elemMatch:{$eq: ?0}}}")
     public List<T> findByUserName(String userName);
+
+    public T findByKey(String key);
 }

--- a/src/main/java/com/pimp/services/GroupService.java
+++ b/src/main/java/com/pimp/services/GroupService.java
@@ -25,15 +25,24 @@ public abstract class GroupService<T extends Group> {
         repository.save(group);
     }
 
+    public T findByKey(String key) {
+      T group = repository.findByKey(key);
+
+      if (group == null) {
+        throw new EntityNotFoundException(getGroupType() + " with key " + key + " does not exist.");
+      }
+
+      return group;
+    }
 
     public T find(String name) {
-        T group = repository.findByName(name);
+      T group = repository.findByName(name);
 
-        if (group == null) {
-            throw new EntityNotFoundException(getGroupType() + " " + name + " does not exist.");
-        }
+      if (group == null) {
+        throw new EntityNotFoundException(getGroupType() + " " + name + " does not exist.");
+      }
 
-        return group;
+      return group;
     }
 
     public List<T> findByUserName(String userName) {

--- a/src/test/java/com/pimp/controller/ProjectControllerTest.java
+++ b/src/test/java/com/pimp/controller/ProjectControllerTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.Arrays;
@@ -123,4 +124,19 @@ public class ProjectControllerTest {
         server.perform(delete("/project/foo/userFoo"))
                 .andExpect(status().isNotFound());
     }
+
+  @Test
+  public void testFindByKey() throws Exception {
+    Project project = new Project()
+      .setName("Foo")
+      .setUserNames(Arrays.asList("PatrickBateman", "PaulAllen"));
+    project.setKey("foo");
+
+    when(projectService.findByKey(anyString())).thenReturn(project);
+
+    ResultActions resultActions = server.perform(get("/project/id/foo"));
+    resultActions
+      .andExpect(status().isOk())
+      .andExpect(content().json("{\"key\":\"foo\",\"name\":\"Foo\",\"userNames\":[\"PatrickBateman\", \"PaulAllen\"]}"));
+  }
 }

--- a/src/test/java/com/pimp/services/ProjectServiceTest.java
+++ b/src/test/java/com/pimp/services/ProjectServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,4 +79,21 @@ public class ProjectServiceTest {
 
         service.delete("foo");
     }
+
+  @Test
+  public void testFindByKey() throws Exception {
+    Project assertedProject = new Project();
+    when(repository.findByKey(any())).thenReturn(assertedProject);
+
+    Project actualProject = service.findByKey("foo");
+
+    assertThat(actualProject).isEqualTo(assertedProject);
+  }
+
+  @Test(expected = EntityNotFoundException.class)
+  public void testFindNonExistingByKey() throws Exception {
+    when(repository.findByKey(any())).thenReturn(null);
+
+    service.findByKey("foo");
+  }
 }


### PR DESCRIPTION
this adds the endpoints /team/id/{key} and /project/id/{key} to find teams/projects by key rather than by name. I also left the old ones in, to enable an easier transition for the frontend, but marked them as deprecated.